### PR TITLE
Improve poster auto layout and automate PDF export

### DIFF
--- a/styles/content.css
+++ b/styles/content.css
@@ -195,6 +195,9 @@ body.uconn-menu-preview {
   --uconn-space-mod-md: calc(var(--uconn-space-mod-total) * 0.65);
   --uconn-space-mod-sm: calc(var(--uconn-space-mod-total) * 0.45);
   --uconn-space-mod-xs: calc(var(--uconn-space-mod-total) * 0.3);
+  --uconn-line-height-auto: 1;
+  --uconn-line-height-total: var(--uconn-line-height-auto);
+  --uconn-poster-padding-auto: 0px;
   /* preview width attempts to reflect final 25cm x 20cm page size */
   width: min(96vw, 25cm);
   max-width: 25cm;
@@ -222,10 +225,10 @@ body.uconn-menu-preview {
   border-radius: 0;
   box-shadow: none;
   box-sizing: border-box;
-  padding: max(4px, calc(12px - var(--uconn-space-mod-md)));
+  padding: max(4px, calc(12px - var(--uconn-space-mod-md) - var(--uconn-poster-padding-auto)));
   display: flex;
   flex-direction: column;
-  gap: max(12px, calc(28px - var(--uconn-space-mod-lg)));
+  gap: max(12px, calc(28px - var(--uconn-space-mod-lg) - var(--uconn-poster-padding-auto)));
   font-family: 'League Spartan', sans-serif;
   font-weight: 700;
   color: #1f2937;
@@ -242,11 +245,12 @@ body.uconn-menu-preview {
 .uconn-menu-poster__header {
   background: #0b2c6a;
   border-radius: 0;
-  padding: max(8px, calc(20px - var(--uconn-space-mod-md))) max(16px, calc(40px - var(--uconn-space-mod-lg)));
+  padding: max(8px, calc(20px - var(--uconn-space-mod-md) - (var(--uconn-poster-padding-auto) * 0.6)))
+    max(16px, calc(40px - var(--uconn-space-mod-lg) - (var(--uconn-poster-padding-auto) * 0.6)));
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: max(16px, calc(40px - var(--uconn-space-mod-lg)));
+  gap: max(16px, calc(40px - var(--uconn-space-mod-lg) - (var(--uconn-poster-padding-auto) * 0.5)));
 }
 
 .uconn-menu-poster__logo {
@@ -260,7 +264,7 @@ body.uconn-menu-preview {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: max(2px, calc(6px - var(--uconn-space-mod-xs)));
+  gap: max(2px, calc(6px - var(--uconn-space-mod-xs) - (var(--uconn-poster-padding-auto) * 0.2)));
 }
 
 .uconn-menu-poster__title {
@@ -269,7 +273,7 @@ body.uconn-menu-preview {
   font-size: calc(60px + var(--uconn-font-scale-total));
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  line-height: 1;
+  line-height: calc(1 * var(--uconn-line-height-total));
 }
 
 .uconn-menu-poster__date {
@@ -277,6 +281,7 @@ body.uconn-menu-preview {
   font-weight: 700;
   letter-spacing: 0.08em;
   color: #ffffff;
+  line-height: calc(1.15 * var(--uconn-line-height-total));
 }
 
 .uconn-menu-poster__subtitle {
@@ -284,6 +289,7 @@ body.uconn-menu-preview {
   font-weight: 600;
   letter-spacing: 0.08em;
   color: #ffffff;
+  line-height: calc(1.2 * var(--uconn-line-height-total));
 }
 
 .uconn-menu-poster__subtitle-em {
@@ -299,11 +305,12 @@ body.uconn-menu-preview {
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: #0b2c6a;
+  line-height: calc(1.1 * var(--uconn-line-height-total));
 }
 
 .uconn-menu-poster__grid {
   display: grid;
-  gap: max(10px, calc(24px - var(--uconn-space-mod-lg)));
+  gap: max(10px, calc(24px - var(--uconn-space-mod-lg) - (var(--uconn-poster-padding-auto) * 0.6)));
   grid-template-columns: repeat(3, minmax(0, 1fr));
   justify-items: stretch;
 }
@@ -311,7 +318,7 @@ body.uconn-menu-preview {
 .uconn-menu-meal {
   display: flex;
   flex-direction: column;
-  gap: max(4px, calc(16px - var(--uconn-space-mod-md)));
+  gap: max(4px, calc(16px - var(--uconn-space-mod-md) - (var(--uconn-poster-padding-auto) * 0.4)));
   min-height: 100%;
 }
 
@@ -325,18 +332,19 @@ body.uconn-menu-preview {
   color: #0b2c6a;
   padding-bottom: max(0px, calc(6px - var(--uconn-space-mod-sm)));
   border-bottom: max(0px, calc(3px - var(--uconn-space-mod-xs))) solid #0b2c6a;
+  line-height: calc(1.05 * var(--uconn-line-height-total));
 }
 
 .uconn-menu-meal__items {
   display: grid;
   grid-template-columns: repeat(var(--uconn-meal-columns, 2), minmax(0, 1fr));
-  gap: max(6px, calc(16px - var(--uconn-space-mod-md)));
+  gap: max(6px, calc(16px - var(--uconn-space-mod-md) - (var(--uconn-poster-padding-auto) * 0.4)));
 }
 
 .uconn-menu-meal__column {
   display: flex;
   flex-direction: column;
-  gap: max(2px, calc(10px - var(--uconn-space-mod-sm)));
+  gap: max(2px, calc(10px - var(--uconn-space-mod-sm) - (var(--uconn-poster-padding-auto) * 0.3)));
 }
 
 .uconn-menu-item {
@@ -362,6 +370,7 @@ body.uconn-menu-preview {
   margin-top: max(2px, calc(12px - var(--uconn-space-mod-md)));
   margin-bottom: max(0px, calc(4px - var(--uconn-space-mod-xs)));
   break-inside: avoid;
+  line-height: calc(1.2 * var(--uconn-line-height-total));
 }
 
 .uconn-menu-meal__items > .uconn-menu-item__category:first-child {
@@ -372,7 +381,7 @@ body.uconn-menu-preview {
   font-size: calc(20px + var(--uconn-font-scale-total));
   font-weight: 700;
   color: #1f2937;
-  line-height: 1.35;
+  line-height: calc(1.35 * var(--uconn-line-height-total));
 }
 
 .uconn-menu-item__note {
@@ -381,6 +390,7 @@ body.uconn-menu-preview {
   font-style: italic;
   font-weight: 700;
   margin-top: max(0px, calc(4px - var(--uconn-space-mod-xs)));
+  line-height: calc(1.3 * var(--uconn-line-height-total));
 }
 
 .uconn-menu-item__allergens {
@@ -388,6 +398,7 @@ body.uconn-menu-preview {
   color: #d93030;
   font-weight: 700;
   margin-top: max(0px, calc(6px - var(--uconn-space-mod-sm)));
+  line-height: calc(1.25 * var(--uconn-line-height-total));
 }
 
 .uconn-menu-item__tags {
@@ -397,6 +408,7 @@ body.uconn-menu-preview {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   margin-top: max(0px, calc(6px - var(--uconn-space-mod-sm)));
+  line-height: calc(1.2 * var(--uconn-line-height-total));
 }
 
 .uconn-menu-item[data-suggested='true'] .uconn-menu-item__title {
@@ -421,10 +433,10 @@ body.uconn-menu-preview {
   border-radius: 22px;
   box-shadow: 0 30px 60px rgba(15, 39, 85, 0.35);
   box-sizing: border-box;
-  padding: 48px 64px;
+  padding: calc(48px - (var(--uconn-poster-padding-auto) * 0.6)) calc(64px - (var(--uconn-poster-padding-auto) * 0.6));
   display: flex;
   flex-direction: column;
-  gap: max(18px, calc(40px - var(--uconn-space-mod-lg)));
+  gap: max(18px, calc(40px - var(--uconn-space-mod-lg) - (var(--uconn-poster-padding-auto) * 0.6)));
   align-items: center;
   text-align: center;
   color: #ffffff;
@@ -436,31 +448,34 @@ body.uconn-menu-preview {
   font-size: calc(60px + var(--uconn-font-scale-total));
   letter-spacing: 0.1em;
   text-transform: uppercase;
+  line-height: calc(1.05 * var(--uconn-line-height-total));
 }
 
 .uconn-menu-info__section {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: max(10px, calc(24px - var(--uconn-space-mod-lg)));
+  gap: max(10px, calc(24px - var(--uconn-space-mod-lg) - (var(--uconn-poster-padding-auto) * 0.6)));
 }
 
 .uconn-menu-info__section-title {
   font-size: calc(26px + var(--uconn-font-scale-total));
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  line-height: calc(1.1 * var(--uconn-line-height-total));
 }
 
 .uconn-menu-info__grid {
   display: grid;
-  gap: max(12px, calc(28px - var(--uconn-space-mod-md))) max(20px, calc(48px - var(--uconn-space-mod-lg)));
+  gap: max(12px, calc(28px - var(--uconn-space-mod-md) - (var(--uconn-poster-padding-auto) * 0.5)))
+    max(20px, calc(48px - var(--uconn-space-mod-lg) - (var(--uconn-poster-padding-auto) * 0.6)));
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .uconn-menu-info__group {
   display: flex;
   flex-direction: column;
-  gap: max(4px, calc(8px - var(--uconn-space-mod-sm)));
+  gap: max(4px, calc(8px - var(--uconn-space-mod-sm) - (var(--uconn-poster-padding-auto) * 0.3)));
   align-items: center;
 }
 
@@ -468,28 +483,33 @@ body.uconn-menu-preview {
   font-size: calc(18px + var(--uconn-font-scale-total));
   letter-spacing: 0.05em;
   text-transform: uppercase;
+  line-height: calc(1.1 * var(--uconn-line-height-total));
 }
 
 .uconn-menu-info__line {
   font-size: calc(16px + var(--uconn-font-scale-total));
   letter-spacing: 0.03em;
+  line-height: calc(1.25 * var(--uconn-line-height-total));
 }
 
 .uconn-menu-info__footer {
   font-size: calc(18px + var(--uconn-font-scale-total));
   letter-spacing: 0.1em;
+  line-height: calc(1.1 * var(--uconn-line-height-total));
 }
 
 @media (max-width: 1024px) {
   #uconn-menu-poster,
   .uconn-menu-poster {
-    padding: 32px 28px;
+    padding: calc(32px - (var(--uconn-poster-padding-auto) * 0.4))
+      calc(28px - (var(--uconn-poster-padding-auto) * 0.4));
     width: min(92vw, 900px);
   }
 
   .uconn-menu-poster__header {
-    padding: 24px 32px;
-    gap: 24px;
+    padding: calc(24px - (var(--uconn-poster-padding-auto) * 0.4))
+      calc(32px - (var(--uconn-poster-padding-auto) * 0.4));
+    gap: max(16px, calc(24px - (var(--uconn-poster-padding-auto) * 0.4)));
   }
 
   .uconn-menu-poster__logo {
@@ -515,13 +535,14 @@ body.uconn-menu-preview {
 
   .uconn-menu-info {
     width: min(92vw, 900px);
-    padding: 36px 24px;
-    gap: 32px;
+    padding: calc(36px - (var(--uconn-poster-padding-auto) * 0.4))
+      calc(24px - (var(--uconn-poster-padding-auto) * 0.4));
+    gap: max(20px, calc(32px - (var(--uconn-poster-padding-auto) * 0.4)));
   }
 
   .uconn-menu-info__grid {
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 24px;
+    gap: max(16px, calc(24px - (var(--uconn-poster-padding-auto) * 0.3)));
   }
 
   .uconn-menu-info__title {


### PR DESCRIPTION
## Summary
- expand the poster auto-scaling routine to tune typography, spacing, line heights, and padding until each page fits the canvas
- adjust the poster stylesheet to respect the new scaling variables and tighten layout gaps when necessary
- trigger a high-resolution PDF export automatically once the preview is rendered and assets are ready

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68dfda266bd083259933b680e3bd4753