### PR TITLE
Add delete control for dishes in poster preview

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -550,6 +550,64 @@
     });
   };
 
+  /**
+   * Adds a delete control to an individual dish card and removes orphaned category labels.
+   */
+  const attachDishDeleteControl = (ctx, card) => {
+    if (!ctx || !card) {
+      return;
+    }
+
+    const deleteButton = ctx.createElement("button");
+    deleteButton.type = "button";
+    deleteButton.className = "uconn-menu-item__delete";
+    deleteButton.setAttribute("aria-label", "Remove dish");
+    deleteButton.innerText = "×";
+    deleteButton.addEventListener("click", (event) => {
+      if (event) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+
+      const parentColumn = card.parentElement;
+      if (!parentColumn) {
+        card.remove();
+        return;
+      }
+
+      let categoryLabel = null;
+      let previous = card.previousElementSibling;
+      while (previous) {
+        if (previous.classList && previous.classList.contains("uconn-menu-item__category")) {
+          categoryLabel = previous;
+          break;
+        }
+        if (previous.classList && previous.classList.contains("uconn-menu-item")) {
+          break;
+        }
+        previous = previous.previousElementSibling;
+      }
+
+      card.remove();
+
+      if (!categoryLabel || categoryLabel.parentElement !== parentColumn) {
+        return;
+      }
+
+      let sibling = categoryLabel.nextElementSibling;
+      while (sibling && !(sibling.classList && sibling.classList.contains("uconn-menu-item__category"))) {
+        if (sibling.classList && sibling.classList.contains("uconn-menu-item")) {
+          return;
+        }
+        sibling = sibling.nextElementSibling;
+      }
+
+      categoryLabel.remove();
+    });
+
+    card.appendChild(deleteButton);
+  };
+
   const createMealColumn = (ctx, meal) => {
     const section = ctx.createElement("section");
     section.className = "uconn-menu-meal";
@@ -606,6 +664,8 @@
         category: categoryName,
         element: card
       });
+
+      attachDishDeleteControl(ctx, card);
     });
 
     distributeMealItemsIntoColumns(ctx, list, entries);

--- a/styles/content.css
+++ b/styles/content.css
@@ -349,6 +349,33 @@ body.uconn-menu-preview {
   page-break-inside: avoid;
 }
 
+.uconn-menu-item__delete {
+  position: absolute;
+  top: 0;
+  right: 0;
+  transform: translate(50%, -50%);
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(11, 44, 106, 0.12);
+  color: #0b2c6a;
+  font-family: 'League Spartan', sans-serif;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.uconn-menu-item__delete:hover {
+  background: rgba(11, 44, 106, 0.2);
+  transform: translate(50%, -50%) scale(1.05);
+}
+
 .uconn-menu-item:last-child {
   border-bottom: none;
 }
@@ -410,6 +437,12 @@ body.uconn-menu-preview {
 
 .uconn-menu-item[data-suggested='true'] .uconn-menu-item__tags {
   color: #0f7760;
+}
+
+@media print {
+  .uconn-menu-item__delete {
+    display: none;
+  }
 }
 
 .uconn-menu-info {


### PR DESCRIPTION
## Summary
- add an inline delete control to each dish card so individual items can be removed from the preview
- clean up empty category labels when the last dish is deleted and style the new control, hiding it during print

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e00a0df8f083258f9d5b262da84243