### PR TITLE
Hide delete controls when generating PDFs

### DIFF
--- a/styles/content.css
+++ b/styles/content.css
@@ -574,6 +574,10 @@ body[data-uconn-printing='true'] {
   background: #ffffff !important;
 }
 
+body[data-uconn-printing='true'] .uconn-menu-item__delete {
+  display: none !important;
+}
+
 body[data-uconn-printing='true'] .uconn-menu-document {
   padding: 0 !important;
   background: transparent !important;


### PR DESCRIPTION
## Summary
- ensure menu item delete controls are hidden whenever the document enters the printing state so they do not appear in generated PDFs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e00bb4ee148325ac89fb433c0337fc