### PR TITLE
Convert poster export to canvas-based PDF workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Chrome extension that turns UConn Dining's "short menu" pages into a Canva-style
 - Click the button to open the overlay poster.
   - Click a menu item to toggle the green "suggested" styling.
   - Double-click text (titles, notes, allergens, categories) to tweak wording or add ratings.
-  - Press **Print Poster** to open Chrome's print dialog; only the poster is rendered in the PDF/export.
+  - Press **Download PDF** to automatically export the poster; all pages are rendered to canvases before saving the PDF.
   - Use the `×` button to close the overlay when you are done.
 
 ## Customising the look


### PR DESCRIPTION
## Summary
- add helpers that render poster pages to canvases and save them via jsPDF
- switch the PDF export to use the new canvas workflow so pages auto-download without print dialogs
- update the README to describe the automatic canvas-to-PDF export

## Testing
- not run (extension)


------
https://chatgpt.com/codex/tasks/task_b_68e0a9d5162c8325b2f7713182ecb1e8