### PR TITLE
Add download control for print layout

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -14,6 +14,7 @@
   })();
   const HTML2PDF_SCRIPT_ID = "uconn-menu-html2pdf-script";
   const HTML2PDF_SCRIPT_SRC = "https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js";
+  const PRINT_DOWNLOAD_BUTTON_ID = "uconn-menu-print-download";
   const html2PdfPromises = new WeakMap();
   const MENU_SECTION_SELECTOR = ".shortmenumeals";
   const NUTRITION_LINK_SELECTOR = "#pg-60-3 a[href*='shortmenu.aspx']";
@@ -1097,6 +1098,21 @@
     const actions = previewDoc.createElement("div");
     actions.className = "uconn-menu-toolbar__actions";
 
+    /** Binds the download handler so all download buttons share the same behavior. */
+    const bindDownloadHandler = (button) => {
+      if (!button) {
+        return;
+      }
+      button.addEventListener("click", () => {
+        button.disabled = true;
+        button.classList.add("is-disabled");
+        Promise.resolve(printPoster(previewWindow, previewDoc)).finally(() => {
+          button.disabled = false;
+          button.classList.remove("is-disabled");
+        });
+      });
+    };
+
     const fontSmallerButton = previewDoc.createElement("button");
     fontSmallerButton.type = "button";
     fontSmallerButton.className = "uconn-menu-toolbar__button";
@@ -1175,14 +1191,7 @@
     printButton.type = "button";
     printButton.className = "uconn-menu-toolbar__button uconn-menu-toolbar__button--primary";
     printButton.innerText = "Download PDF";
-    printButton.addEventListener("click", () => {
-      printButton.disabled = true;
-      printButton.classList.add("is-disabled");
-      Promise.resolve(printPoster(previewWindow, previewDoc)).finally(() => {
-        printButton.disabled = false;
-        printButton.classList.remove("is-disabled");
-      });
-    });
+    bindDownloadHandler(printButton);
 
     const closeButton = previewDoc.createElement("button");
     closeButton.type = "button";
@@ -1216,6 +1225,14 @@
     documentRoot.appendChild(pages);
 
     previewDoc.body.appendChild(documentRoot);
+
+    const printStateDownloadButton = previewDoc.createElement("button");
+    printStateDownloadButton.type = "button";
+    printStateDownloadButton.id = PRINT_DOWNLOAD_BUTTON_ID;
+    printStateDownloadButton.className = "uconn-menu-print-download";
+    printStateDownloadButton.innerText = "Download PDF";
+    bindDownloadHandler(printStateDownloadButton);
+    previewDoc.body.appendChild(printStateDownloadButton);
     applyAutoFontScaling(previewWindow, previewDoc);
     previewWindow.focus();
 

--- a/styles/content.css
+++ b/styles/content.css
@@ -593,10 +593,53 @@ body[data-uconn-printing='true'] .uconn-menu-page {
   page-break-after: always;
 }
 
+body[data-uconn-printing='true'] .uconn-menu-print-download {
+  display: inline-flex;
+}
+
 body[data-uconn-printing='true'] #uconn-menu-poster,
 body[data-uconn-printing='true'] .uconn-menu-poster,
 body[data-uconn-printing='true'] .uconn-menu-info {
   box-shadow: none !important;
   margin: 0 auto !important;
   border: none !important;
+}
+
+.uconn-menu-print-download {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 24px;
+  border-radius: 9999px;
+  background: #0b2c6a;
+  color: #ffffff;
+  border: none;
+  font-family: inherit;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.25;
+  cursor: pointer;
+  box-shadow: 0 10px 20px rgba(11, 44, 106, 0.25);
+  transition: background-color 0.2s ease, transform 0.2s ease;
+  z-index: 2147483647;
+}
+
+.uconn-menu-print-download:hover {
+  background: #07204a;
+  transform: translateY(-1px);
+}
+
+.uconn-menu-print-download:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 2px;
+}
+
+.uconn-menu-print-download.is-disabled {
+  opacity: 0.6;
+  cursor: progress;
+  pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- add a shared download handler for preview download buttons
- render an additional download control that is visible during the print layout state
- style the print layout download control to match the existing primary action

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e2c84526c88325bf01a0ba0588be60