### PR TITLE
Remove external html2pdf dependency and rely on browser print dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Chrome extension that turns UConn Dining's "short menu" pages into a Canva-style
 - Click the button to open the overlay poster.
   - Click a menu item to toggle the green "suggested" styling.
   - Double-click text (titles, notes, allergens, categories) to tweak wording or add ratings.
-  - Press **Download PDF** to automatically export the poster; all pages are rendered to canvases before saving the PDF.
+  - Press **Print / Save PDF** to open the browser print dialog and export the poster. Use the system "Save as PDF" option to download.
   - Use the `×` button to close the overlay when you are done.
 
 ## Customising the look


### PR DESCRIPTION
## Summary
- remove the html2pdf loader and call the browser print dialog instead to avoid CSP violations
- update the preview toolbar button label to reflect the print-based export flow
- refresh the README instructions to explain saving through the print dialog

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e32cd92f3483258e19ca606c97a1a5