### PR TITLE
Remove PDF download button and improve print layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Chrome extension that turns UConn Dining's "short menu" pages into a Canva-style
 - Click the button to open the overlay poster.
   - Click a menu item to toggle the green "suggested" styling.
   - Double-click text (titles, notes, allergens, categories) to tweak wording or add ratings.
-  - Press **Download PDF** to automatically export the poster; all pages are rendered to canvases before saving the PDF.
+  - Use your browser's **Print** dialog to export a PDF; the layout matches the on-screen preview.
   - Use the `×` button to close the overlay when you are done.
 
 ## Customising the look

--- a/content-script.js
+++ b/content-script.js
@@ -14,7 +14,6 @@
   })();
   const HTML2PDF_SCRIPT_ID = "uconn-menu-html2pdf-script";
   const HTML2PDF_SCRIPT_SRC = "https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js";
-  const PRINT_DOWNLOAD_BUTTON_ID = "uconn-menu-print-download";
   const html2PdfPromises = new WeakMap();
   const MENU_SECTION_SELECTOR = ".shortmenumeals";
   const NUTRITION_LINK_SELECTOR = "#pg-60-3 a[href*='shortmenu.aspx']";
@@ -1076,10 +1075,6 @@
     previewDoc.body.classList.add("uconn-menu-preview");
     ensureStylesheet(previewDoc);
     ensureFonts(previewDoc);
-    ensureHtml2Pdf(previewWindow, previewDoc).catch((error) => {
-      previewWindow.console?.warn?.("[UConn Menu Formatter] html2pdf failed to preload", error);
-    });
-
     const closePreview = () => {
       setPrintingState(previewDoc, false);
       previewWindow.close();
@@ -1097,21 +1092,6 @@
 
     const actions = previewDoc.createElement("div");
     actions.className = "uconn-menu-toolbar__actions";
-
-    /** Binds the download handler so all download buttons share the same behavior. */
-    const bindDownloadHandler = (button) => {
-      if (!button) {
-        return;
-      }
-      button.addEventListener("click", () => {
-        button.disabled = true;
-        button.classList.add("is-disabled");
-        Promise.resolve(printPoster(previewWindow, previewDoc)).finally(() => {
-          button.disabled = false;
-          button.classList.remove("is-disabled");
-        });
-      });
-    };
 
     const fontSmallerButton = previewDoc.createElement("button");
     fontSmallerButton.type = "button";
@@ -1187,12 +1167,6 @@
     fontControls.appendChild(fontSmallerButton);
     fontControls.appendChild(fontBiggerButton);
 
-    const printButton = previewDoc.createElement("button");
-    printButton.type = "button";
-    printButton.className = "uconn-menu-toolbar__button uconn-menu-toolbar__button--primary";
-    printButton.innerText = "Download PDF";
-    bindDownloadHandler(printButton);
-
     const closeButton = previewDoc.createElement("button");
     closeButton.type = "button";
     closeButton.className = "uconn-menu-toolbar__button uconn-menu-toolbar__button--secondary";
@@ -1201,7 +1175,6 @@
 
     actions.appendChild(fontControls);
     actions.appendChild(colorPalette);
-    actions.appendChild(printButton);
     actions.appendChild(closeButton);
 
     toolbar.appendChild(instructions);
@@ -1226,13 +1199,6 @@
 
     previewDoc.body.appendChild(documentRoot);
 
-    const printStateDownloadButton = previewDoc.createElement("button");
-    printStateDownloadButton.type = "button";
-    printStateDownloadButton.id = PRINT_DOWNLOAD_BUTTON_ID;
-    printStateDownloadButton.className = "uconn-menu-print-download";
-    printStateDownloadButton.innerText = "Download PDF";
-    bindDownloadHandler(printStateDownloadButton);
-    previewDoc.body.appendChild(printStateDownloadButton);
     applyAutoFontScaling(previewWindow, previewDoc);
     previewWindow.focus();
 

--- a/styles/content.css
+++ b/styles/content.css
@@ -144,12 +144,6 @@ body.uconn-menu-preview {
   letter-spacing: 0.02em;
 }
 
-.uconn-menu-toolbar__actions {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-
 .uconn-menu-toolbar__button {
   border: none;
   border-radius: 999px;
@@ -160,17 +154,6 @@ body.uconn-menu-preview {
   letter-spacing: 0.04em;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-}
-
-.uconn-menu-toolbar__button--primary {
-  background: #22c55e;
-  color: #0f7760;
-  box-shadow: 0 12px 24px rgba(34, 197, 94, 0.35);
-}
-
-.uconn-menu-toolbar__button--primary:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 16px 30px rgba(34, 197, 94, 0.42);
 }
 
 .uconn-menu-toolbar__button--secondary {
@@ -237,6 +220,8 @@ body.uconn-menu-preview {
   body, .uconn-menu-document { margin: 0; padding: 0; }
   .uconn-menu-pages { width: 25cm; }
   #uconn-menu-poster, .uconn-menu-poster { width: 25cm; height: 20cm; box-shadow: none; border-width: 0.4cm; }
+  .uconn-menu-poster__grid { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+  .uconn-menu-info__grid { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
 }
 
 .uconn-menu-poster__header {
@@ -299,6 +284,12 @@ body.uconn-menu-preview {
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: #0b2c6a;
+}
+
+.uconn-menu-toolbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
 }
 
 .uconn-menu-poster__grid {
@@ -562,8 +553,8 @@ body.uconn-menu-preview {
   }
 }
 
-/* Ensure columns collapse to a single column on narrow previews and for print tools that don't support columns well */
-@media (max-width: 720px), print {
+/* Ensure columns collapse to a single column on narrow previews */
+@media (max-width: 720px) {
   .uconn-menu-meal__items {
     grid-template-columns: 1fr !important;
     gap: max(2px, calc(10px - var(--uconn-space-mod-sm))) !important;
@@ -593,10 +584,6 @@ body[data-uconn-printing='true'] .uconn-menu-page {
   page-break-after: always;
 }
 
-body[data-uconn-printing='true'] .uconn-menu-print-download {
-  display: inline-flex;
-}
-
 body[data-uconn-printing='true'] #uconn-menu-poster,
 body[data-uconn-printing='true'] .uconn-menu-poster,
 body[data-uconn-printing='true'] .uconn-menu-info {
@@ -605,41 +592,11 @@ body[data-uconn-printing='true'] .uconn-menu-info {
   border: none !important;
 }
 
-.uconn-menu-print-download {
-  position: fixed;
-  bottom: 24px;
-  right: 24px;
-  display: none;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 12px 24px;
-  border-radius: 9999px;
-  background: #0b2c6a;
-  color: #ffffff;
-  border: none;
-  font-family: inherit;
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 1.25;
-  cursor: pointer;
-  box-shadow: 0 10px 20px rgba(11, 44, 106, 0.25);
-  transition: background-color 0.2s ease, transform 0.2s ease;
-  z-index: 2147483647;
+body[data-uconn-printing='true'] .uconn-menu-poster__grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.uconn-menu-print-download:hover {
-  background: #07204a;
-  transform: translateY(-1px);
+body[data-uconn-printing='true'] .uconn-menu-info__grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.uconn-menu-print-download:focus-visible {
-  outline: 3px solid rgba(255, 255, 255, 0.8);
-  outline-offset: 2px;
-}
-
-.uconn-menu-print-download.is-disabled {
-  opacity: 0.6;
-  cursor: progress;
-  pointer-events: none;
-}


### PR DESCRIPTION
## Summary
- remove the dedicated Download PDF buttons from the preview toolbar and related styles
- update the README to direct users to export via the browser print dialog instead
- adjust print styling so poster grids keep the responsive column counts when exporting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e343a9dc208325b93e0c3073810a18