### PR TITLE
Improve print handling for menu preview

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -970,6 +970,14 @@
     previewDoc.body.classList.add("uconn-menu-preview");
     ensureStylesheet(previewDoc);
     ensureFonts(previewDoc);
+    const handleBeforePrint = () => setPrintingState(previewDoc, true);
+    const handleAfterPrint = () => setPrintingState(previewDoc, false);
+    previewWindow.addEventListener("beforeprint", handleBeforePrint);
+    previewWindow.addEventListener("afterprint", handleAfterPrint);
+    previewWindow.addEventListener("unload", () => {
+      previewWindow.removeEventListener("beforeprint", handleBeforePrint);
+      previewWindow.removeEventListener("afterprint", handleAfterPrint);
+    });
     const closePreview = () => {
       setPrintingState(previewDoc, false);
       previewWindow.close();

--- a/styles/content.css
+++ b/styles/content.css
@@ -73,6 +73,12 @@ body.uconn-menu-preview {
   color: #ffffff;
 }
 
+body[data-uconn-printing='true'] .uconn-menu-toolbar,
+body[data-uconn-printing='true'] .uconn-menu-trigger-wrapper,
+body[data-uconn-printing='true'] .uconn-menu-trigger__date-label {
+  display: none !important;
+}
+
 .uconn-menu-document {
   width: 100%;
   min-height: 100vh;
@@ -237,6 +243,14 @@ body.uconn-menu-preview {
   body, .uconn-menu-document { margin: 0; padding: 0; }
   .uconn-menu-pages { width: 25cm; }
   #uconn-menu-poster, .uconn-menu-poster { width: 25cm; height: 20cm; box-shadow: none; border-width: 0.4cm; }
+  .uconn-menu-toolbar,
+  .uconn-menu-trigger-wrapper,
+  .uconn-menu-trigger__date-label {
+    display: none !important;
+  }
+  body.uconn-menu-preview {
+    background: #ffffff;
+  }
 }
 
 .uconn-menu-poster__header {


### PR DESCRIPTION
## Summary
- hide preview toolbar and trigger controls when initiating printing
- update print styles so only menu pages are shown in the print dialog

## Testing
- not run (extension changes only)


------
https://chatgpt.com/codex/tasks/task_b_68e3e9d8e3008325b565ac0418b881fb