### PR TITLE
Hide toolbar while printing

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -907,6 +907,21 @@
     ctxDoc.head.appendChild(link);
   };
 
+  /**
+   * Toggles the preview toolbar visibility when preparing to print.
+   */
+  const setToolbarHiddenForPrint = (ctxDoc, hidden) => {
+    const toolbar = ctxDoc?.querySelector?.(".uconn-menu-toolbar");
+    if (!toolbar) {
+      return;
+    }
+    if (hidden) {
+      toolbar.classList.add("uconn-menu-toolbar--hidden-for-print");
+    } else {
+      toolbar.classList.remove("uconn-menu-toolbar--hidden-for-print");
+    }
+  };
+
   const setPrintingState = (ctxDoc, isPrinting) => {
     if (!ctxDoc?.body) {
       return;
@@ -916,6 +931,7 @@
     } else {
       delete ctxDoc.body.dataset.uconnPrinting;
     }
+    setToolbarHiddenForPrint(ctxDoc, Boolean(isPrinting));
   };
 
   const printPoster = async (previewWindow, ctxDoc) => {

--- a/styles/content.css
+++ b/styles/content.css
@@ -108,6 +108,10 @@ body[data-uconn-printing='true'] .uconn-menu-trigger__date-label {
   color: #ffffff;
 }
 
+.uconn-menu-toolbar--hidden-for-print {
+  display: none !important;
+}
+
 .uconn-menu-toolbar__font-controls {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- ensure the print routine toggles a dedicated class to hide the preview toolbar while the browser print dialog is open
- add a CSS helper class so the toolbar stays hidden whenever printing is in progress

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e3edf5656483258c93382b635c6547