### PR TITLE
Add print prompt button that hides toolbar before printing

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -1167,6 +1167,32 @@
     fontControls.appendChild(fontSmallerButton);
     fontControls.appendChild(fontBiggerButton);
 
+    const printButton = previewDoc.createElement("button");
+    printButton.type = "button";
+    printButton.className = "uconn-menu-toolbar__button uconn-menu-toolbar__button--primary";
+    printButton.innerText = "Print";
+    printButton.addEventListener("click", () => {
+      if (!toolbar) {
+        return;
+      }
+      toolbar.classList.add("uconn-menu-toolbar--hidden");
+      const executePrint = () => {
+        try {
+          previewWindow.focus();
+          previewWindow.print();
+        } finally {
+          toolbar.classList.remove("uconn-menu-toolbar--hidden");
+        }
+      };
+      if (typeof previewWindow.requestAnimationFrame === "function") {
+        previewWindow.requestAnimationFrame(() => {
+          previewWindow.setTimeout(executePrint, 0);
+        });
+      } else {
+        previewWindow.setTimeout(executePrint, 0);
+      }
+    });
+
     const closeButton = previewDoc.createElement("button");
     closeButton.type = "button";
     closeButton.className = "uconn-menu-toolbar__button uconn-menu-toolbar__button--secondary";
@@ -1175,6 +1201,7 @@
 
     actions.appendChild(fontControls);
     actions.appendChild(colorPalette);
+    actions.appendChild(printButton);
     actions.appendChild(closeButton);
 
     toolbar.appendChild(instructions);

--- a/styles/content.css
+++ b/styles/content.css
@@ -102,6 +102,10 @@ body.uconn-menu-preview {
   color: #ffffff;
 }
 
+.uconn-menu-toolbar--hidden {
+  display: none !important;
+}
+
 .uconn-menu-toolbar__font-controls {
   display: flex;
   align-items: center;
@@ -154,6 +158,17 @@ body.uconn-menu-preview {
   letter-spacing: 0.04em;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.uconn-menu-toolbar__button--primary {
+  background: #ffffff;
+  color: #0b2c6a;
+  box-shadow: 0 12px 24px rgba(15, 39, 85, 0.25);
+}
+
+.uconn-menu-toolbar__button--primary:hover {
+  transform: translateY(-1px);
+  background: #f3f4f6;
 }
 
 .uconn-menu-toolbar__button--secondary {


### PR DESCRIPTION
## Summary
- add a print action to the preview toolbar that hides the controls before invoking the browser print dialog
- add styling helpers so the toolbar can be hidden and the print action renders as a primary button

## Testing
- not run (extension UI change)


------
https://chatgpt.com/codex/tasks/task_b_68e3f6087f4c832594b65c356244f4e2